### PR TITLE
Fix reset headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Defaults are given here
 - `userLimit`: `300` number of total requests a user can make per period.  Set to `false` to disable limiting requests per user.
 - `userCache`: Object with the following properties:
     -  `segment`: `hapi-rate-limit-user` Name of the cache segment to use for storing user rate limit info
-    - `expiresIn`: `600000` Time (in seconds) of period for `userLimit`
+    - `expiresIn`: `600000` Time (in milliseconds) of period for `userLimit`
 - `userAttribute`: `id` credentials attribute to use when determining distinct authenticated users
 - `userWhitelist`: `[]` array of users (as defined by `userAttribute` for whom to bypass rate limiting.  This is only applied to authenticated users, for ip whitelisting use `ipWhitelist`.
 - `addressOnly`: `false` if true, only consider user address when determining distinct authenticated users
 - `pathLimit`: `50` number of total requests that can be made on a given path per period.  Set to `false` to disable limiting requests per user.
 - `pathCache`: Object with the following properties:
 	- `segment`: `hapi-rate-limit-path` Name of the cache segment to use for storing path rate limit info
-	- `expiresIn`: `60000` Time (in seconds) of period for `pathLimit`
+	- `expiresIn`: `60000` Time (in milliseconds) of period for `pathLimit`
 - `headers`: `true` Whether or not to include headers in responses
 - `ipWhitelist`: `[]` array of IPs for whom to bypass rate limiting.  Note that a whitelisted IP would also bypass restrictions an authenticated user would otherwise have.
 - `trustProxy`: `false` If true, honor the `X-Forwarded-For` header.  See note below.
@@ -65,10 +65,10 @@ The following headers will be included in server responses if their respective l
 
 - `x-ratelimit-pathlimit`: Will equal `pathLimit`
 - `x-ratelimit-pathremaining`: Remaining number of requests path has this - period
-- `x-ratelimit-pathreset`: Time (in seconds) until reset of `pathLimit` period
+- `x-ratelimit-pathreset`: Time (in milliseconds) until reset of `pathLimit` period
 - `x-ratelimit-userlimit`: Will equal `userLimit`
 - `x-ratelimit-userremaining`: Remaining number of requests user has this period
-- `x-ratelimit-userreset`: Time (in seconds) until reset of `userLimit` period
+- `x-ratelimit-userreset`: Time (in milliseconds) until reset of `userLimit` period
 
 ## Per-route settings
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,7 @@ internals.pathCheck = function (request, settings, done) {
 
             request.plugins[internals.pluginName].pathLimit = settings.pathLimit;
             request.plugins[internals.pluginName].pathRemaining = remaining;
-            request.plugins[internals.pluginName].pathReset = new Date(Date.now() + ttl);
+            request.plugins[internals.pluginName].pathReset = Date.now() + ttl;
 
             return done(null, { count, remaining, reset: settings.pathCache.expiresIn });
         });
@@ -138,7 +138,7 @@ internals.userCheck = function (request, settings, done) {
 
             request.plugins[internals.pluginName].userLimit = settings.userLimit;
             request.plugins[internals.pluginName].userRemaining = remaining;
-            request.plugins[internals.pluginName].userReset = new Date(Date.now() + ttl);
+            request.plugins[internals.pluginName].userReset = Date.now() + ttl;
 
             return done(null, { count, remaining, reset: ttl });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -54,12 +54,12 @@ describe('hapi-rate-limit', () => {
                 ]);
                 expect(res1.headers['x-ratelimit-pathlimit']).to.equal(50);
                 expect(res1.headers['x-ratelimit-pathremaining']).to.equal(50);
-                expect(res1.headers['x-ratelimit-pathreset']).to.be.a.date();
-                expect(res1.headers['x-ratelimit-pathreset'] - new Date()).to.be.within(59900, 60100);
+                expect(res1.headers['x-ratelimit-pathreset']).to.be.a.number();
+                expect(res1.headers['x-ratelimit-pathreset'] - Date.now()).to.be.within(59900, 60100);
                 expect(res1.headers['x-ratelimit-userlimit']).to.equal(300);
                 expect(res1.headers['x-ratelimit-userremaining']).to.equal(300);
-                expect(res1.headers['x-ratelimit-userreset']).to.be.a.date();
-                expect(res1.headers['x-ratelimit-userreset'] - new Date()).to.be.within(599900, 600100);
+                expect(res1.headers['x-ratelimit-userreset']).to.be.a.number();
+                expect(res1.headers['x-ratelimit-userreset'] - Date.now()).to.be.within(599900, 600100);
 
                 return server.inject({ method: 'GET', url: '/defaults' }).then((res2) => {
 
@@ -158,8 +158,8 @@ describe('hapi-rate-limit', () => {
                 ]);
                 expect(res1.headers['x-ratelimit-pathlimit']).to.equal(50);
                 expect(res1.headers['x-ratelimit-pathremaining']).to.equal(50);
-                expect(res1.headers['x-ratelimit-pathreset']).to.be.a.date();
-                expect(res1.headers['x-ratelimit-pathreset'] - new Date()).to.be.within(59900, 60100);
+                expect(res1.headers['x-ratelimit-pathreset']).to.be.a.number();
+                expect(res1.headers['x-ratelimit-pathreset'] - Date.now()).to.be.within(59900, 60100);
 
                 return server.inject({ method: 'GET', url: '/setPathLimit' }).then((res2) => {
 


### PR DESCRIPTION
This changes the userreset and pathreset headers to return numbers instead of date strings.
This also updates the readme to properly document those headers, and the expiresIn settings that populate them