### PR TITLE
Document incompatibility with catbox-redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lead Maintainer: [Gar](https://github.com/wraithgar)
 
 **hapi-rate-limit** is a plugin for [hapi](http://hapijs.com) that enables rate limiting.
 
-It relies on `cache` being defined in the server.
+It relies on `cache` being defined in the server. Due to an issue with [catbox-redis#59](https://github.com/hapijs/catbox-redis/issues/59) it does not work with [catbox-redis](https://github.com/hapijs/catbox-redis) at the moment.
 
 ## Use
 


### PR DESCRIPTION
Since catbox-redis does not allow storing of the integer 0 at the moment (hapijs/catbox-redis#59), the plugin does not work with catbox-redis following the first request. It fails when trying to retrieve the request from the catbox cache.

One way to workaround this, would be to start counting at 1 and not at 0. But this seems rather hacky to me.