### PR TITLE
Adds ability to enable or disable individual routes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const internals = {};
 internals.pluginName = Pkg.name;
 
 internals.defaults = {
+    enabled: true,
     addressOnly: false,
     headers: true,
     ipWhitelist: [],
@@ -165,6 +166,10 @@ exports.register = function (plugin, options, next) {
         const requestSettings = Object.assign({}, settings, routeSettings);
 
         request.plugins[internals.pluginName] = { requestSettings };
+
+        if (requestSettings.enabled === false) {
+            return reply.continue();
+        }
 
         internals.pathCheck(request, requestSettings, (pathCheckErr, path) => {
 

--- a/test/test-routes.js
+++ b/test/test-routes.js
@@ -194,4 +194,19 @@ module.exports = [{
             strategy: 'trusty'
         }
     }
+},{
+    method: 'GET',
+    path: '/pathDisabled',
+    config: {
+        description: 'Route that has disabled rate limiting',
+        handler: (request, reply) => {
+
+            return reply(request.path);
+        },
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        }
+    }
 }];


### PR DESCRIPTION
I have a use case where I just want to enable rate limiting on certain routes.  So I set enabled: false when I register the plugin and then enabled: true on the routes that I want rate limiting on.