### PR TITLE
per-route-user limit and captcha support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Boom = require('boom');
 const Hoek = require('hoek');
 const Pkg = require('../package.json');
+const https = require('https');
 
 const internals = {};
 
@@ -31,6 +32,13 @@ internals.defaults = {
         expiresIn: 10 * 60 * 1000 //10 minutes
     },
     userPathLimit: false,
+    recaptchaOptions: {
+      hostname: 'www.google.com',
+      port: 443,
+      path: '/recaptcha/api/siteverify',
+      method: 'GET'
+    },
+    recaptchaSecret: false
 };
 
 internals.getUser = function getUser(request, settings) {
@@ -201,8 +209,43 @@ internals.userPathCheck = function (request, settings, done) {
             request.plugins[internals.pluginName].userPathRemaining = remaining;
             request.plugins[internals.pluginName].userPathReset = Date.now() + ttl;
 
-            return done(null, { count, remaining, reset: ttl });
+            if (remaining < 0 && settings.recaptchaSecret !== false && request.query && request.query.recaptcha) {
+                internals.verifyCaptcha(request, settings, (err, success) => {
+                    if (err) {
+                    return done(err);
+                  }
+                  return done(null, { count, remaining, reset: ttl, success });
+                });
+            } else {
+                return done(null, { count, remaining, reset: ttl, success: false });
+            }
         });
+    });
+};
+
+internals.verifyCaptcha = function verifyCaptcha(request, settings, done) {
+
+    let options = {
+      hostname: settings.recaptchaOptions.hostname,
+      port: settings.recaptchaOptions.port,
+      path: settings.recaptchaOptions.path + '?secret=' + settings.recaptchaSecret + '&response=' + request.query.recaptcha,
+      method: settings.recaptchaOptions.method,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    let get_request = https.request(options, (res) => {
+      res.setEncoding('utf8');
+      res.on('data', (body) => {
+        return done(null, JSON.parse(body).success);
+      });
+    })
+
+    get_request.end();
+    get_request.on('error', (err) => {
+      request.log([Pkg.name, 'error'], setErr);
+      return done(Boom.badImplementation('could not call API recaptcha verify'));
     });
 };
 
@@ -249,8 +292,7 @@ exports.register = function (plugin, options, next) {
                     if (userPathCheckErr) {
                         return reply(userPathCheckErr);
                     }
-
-                    if (path.remaining < 0 || user.remaining < 0 || userPath.remaining < 0) {
+                    if (path.remaining < 0 || user.remaining < 0 || (userPath.remaining < 0 && !userPath.success)) {
 
                         const error = Boom.tooManyRequests('Rate limit exceeded');
                         if (requestSettings.pathLimit !== false && requestSettings.headers !== false) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,12 @@ internals.defaults = {
         expiresIn: 10 * 60 * 1000 //10 minutes
     },
     userLimit: 300,
-    userWhitelist: []
+    userWhitelist: [],
+    userPathCache: {
+        segment: `${internals.pluginName}-userPath`,
+        expiresIn: 10 * 60 * 1000 //10 minutes
+    },
+    userPathLimit: false,
 };
 
 internals.getUser = function getUser(request, settings) {
@@ -146,12 +151,68 @@ internals.userCheck = function (request, settings, done) {
     });
 };
 
+internals.userPathCheck = function (request, settings, done) {
+
+    const ip = internals.getIP(request, settings);
+    let user = internals.getUser(request, settings);
+    const path = request.path;
+
+    if (
+        (settings.ipWhitelist.indexOf(ip) > -1) ||
+        (user && settings.userWhitelist.indexOf(user) > -1) ||
+        (settings.userPathLimit === false)
+    ) {
+        request.plugins[internals.pluginName].userPathLimit = false;
+        return done(null, { remaining: 1 });
+    }
+
+    if (settings.addressOnly || (user === undefined)) {
+        user = ip;
+    }
+
+    const userPath = user+':'+path;
+
+    internals.userPathCache.get(userPath, (getErr, value, details) => {
+
+        if (getErr) {
+            request.log([Pkg.name, 'error'], getErr);
+            return done(Boom.badImplementation('error getting user-path rate limit info from cache'));
+        };
+
+        let count;
+        let ttl = settings.userPathCache.expiresIn;
+
+        if (value === null || details.isStale) {
+            count = 1;
+        }
+        else {
+            count = value + 1;
+            ttl = details.ttl;
+        }
+        const remaining = settings.userPathLimit - count;
+        internals.userPathCache.set(userPath, count, ttl, (setErr) => {
+
+            if (setErr) {
+                request.log([Pkg.name, 'error'], setErr);
+                return done(Boom.badImplementation('could not set user-path rate limit in cache'));
+            }
+
+            request.plugins[internals.pluginName].userPathLimit = settings.userPathLimit;
+            request.plugins[internals.pluginName].userPathRemaining = remaining;
+            request.plugins[internals.pluginName].userPathReset = Date.now() + ttl;
+
+            return done(null, { count, remaining, reset: ttl });
+        });
+    });
+};
+
 exports.register = function (plugin, options, next) {
 
     const settings = Hoek.applyToDefaults(internals.defaults, options);
 
     internals.userCache = plugin.cache(settings.userCache);
     internals.pathCache = plugin.cache(settings.pathCache);
+    internals.userPathCache = plugin.cache(settings.userPathCache);
 
     plugin.ext('onPostAuth', (request, reply) => {
 
@@ -183,17 +244,34 @@ exports.register = function (plugin, options, next) {
                     return reply(userCheckErr);
                 }
 
-                if (path.remaining < 0 || user.remaining < 0) {
+                internals.userPathCheck(request, requestSettings, (userPathCheckErr, userPath) => {
 
-                    const error = Boom.tooManyRequests('Rate limit exceeded');
-                    if (requestSettings.pathLimit !== false && requestSettings.headers !== false) {
-                        error.output.headers['X-RateLimit-PathLimit'] = request.plugins[internals.pluginName].pathLimit;
-                        error.output.headers['X-RateLimit-PathRemaining'] = request.plugins[internals.pluginName].pathRemaining;
-                        error.output.headers['X-RateLimit-PathReset'] = request.plugins[internals.pluginName].pathReset;
+                    if (userPathCheckErr) {
+                        return reply(userPathCheckErr);
                     }
-                    return reply(error);
-                }
-                return reply.continue();
+
+                    if (path.remaining < 0 || user.remaining < 0 || userPath.remaining < 0) {
+
+                        const error = Boom.tooManyRequests('Rate limit exceeded');
+                        if (requestSettings.pathLimit !== false && requestSettings.headers !== false) {
+                            error.output.headers['X-RateLimit-PathLimit'] = request.plugins[internals.pluginName].pathLimit;
+                            error.output.headers['X-RateLimit-PathRemaining'] = request.plugins[internals.pluginName].pathRemaining;
+                            error.output.headers['X-RateLimit-PathReset'] = request.plugins[internals.pluginName].pathReset;
+                        }
+                        if (requestSettings.userPathLimit !== false && requestSettings.headers !== false) {
+                            error.output.headers['X-RateLimit-UserPathLimit'] = request.plugins[internals.pluginName].userPathLimit;
+                            error.output.headers['X-RateLimit-UserPathRemaining'] = request.plugins[internals.pluginName].userPathRemaining;
+                            error.output.headers['X-RateLimit-UserPathReset'] = request.plugins[internals.pluginName].userPathReset;
+                        }
+                        if (requestSettings.userLimit !== false && requestSettings.headers !== false) {
+                            error.output.headers['X-RateLimit-UserLimit'] = request.plugins[internals.pluginName].userLimit;
+                            error.output.headers['X-RateLimit-UserRemaining'] = request.plugins[internals.pluginName].userRemaining;
+                            error.output.headers['X-RateLimit-UserReset'] = request.plugins[internals.pluginName].userReset;
+                        }
+                        return reply(error);
+                    }
+                    return reply.continue();
+                });
             });
         });
     });
@@ -209,17 +287,15 @@ exports.register = function (plugin, options, next) {
             response.headers['X-RateLimit-PathRemaining'] = requestPlugin.pathRemaining;
             response.headers['X-RateLimit-PathReset'] = requestPlugin.pathReset;
         }
-        if (requestSettings.userLimit !== false && requestSettings.headers !== false && requestPlugin.userLimit !== false) {
-            if (response.isBoom) {
-                response.output.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
-                response.output.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
-                response.output.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
-            }
-            else {
-                response.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
-                response.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
-                response.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
-            }
+        if (!response.isBoom && requestSettings.userPathLimit !== false && requestSettings.headers !== false) {
+            response.headers['X-RateLimit-UserPathLimit'] = requestPlugin.userPathLimit;
+            response.headers['X-RateLimit-UserPathRemaining'] = requestPlugin.userPathRemaining;
+            response.headers['X-RateLimit-UserPathReset'] = requestPlugin.userPathReset;
+        }
+        if (!response.isBoom && requestSettings.userLimit !== false && requestSettings.headers !== false) {
+            response.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
+            response.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
+            response.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
         }
         reply.continue();
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Boom = require('boom');
 const Hoek = require('hoek');
 const Pkg = require('../package.json');
-const https = require('https');
+const HTTPS = require('https');
 
 const internals = {};
 
@@ -33,10 +33,10 @@ internals.defaults = {
     },
     userPathLimit: false,
     recaptchaOptions: {
-      hostname: 'www.google.com',
-      port: 443,
-      path: '/recaptcha/api/siteverify',
-      method: 'GET'
+        hostname: 'www.google.com',
+        port: 443,
+        path: '/recaptcha/api/siteverify',
+        method: 'GET'
     },
     recaptchaSecret: false
 };
@@ -70,7 +70,9 @@ internals.pathCheck = function (request, settings, done) {
 
     if (settings.pathLimit === false) {
         request.plugins[internals.pluginName].pathLimit = false;
-        return done(null, { remaining: 1 });
+        return done(null, {
+            remaining: 1
+        });
     }
 
     internals.pathCache.get(path, (getErr, value, details) => {
@@ -102,7 +104,11 @@ internals.pathCheck = function (request, settings, done) {
             request.plugins[internals.pluginName].pathRemaining = remaining;
             request.plugins[internals.pluginName].pathReset = Date.now() + ttl;
 
-            return done(null, { count, remaining, reset: settings.pathCache.expiresIn });
+            return done(null, {
+                count,
+                remaining,
+                reset: settings.pathCache.expiresIn
+            });
         });
     });
 };
@@ -118,7 +124,9 @@ internals.userCheck = function (request, settings, done) {
         (settings.userLimit === false)
     ) {
         request.plugins[internals.pluginName].userLimit = false;
-        return done(null, { remaining: 1 });
+        return done(null, {
+            remaining: 1
+        });
     }
 
     if (settings.addressOnly || (user === undefined)) {
@@ -154,7 +162,11 @@ internals.userCheck = function (request, settings, done) {
             request.plugins[internals.pluginName].userRemaining = remaining;
             request.plugins[internals.pluginName].userReset = Date.now() + ttl;
 
-            return done(null, { count, remaining, reset: ttl });
+            return done(null, {
+                count,
+                remaining,
+                reset: ttl
+            });
         });
     });
 };
@@ -171,14 +183,16 @@ internals.userPathCheck = function (request, settings, done) {
         (settings.userPathLimit === false)
     ) {
         request.plugins[internals.pluginName].userPathLimit = false;
-        return done(null, { remaining: 1 });
+        return done(null, {
+            remaining: 1
+        });
     }
 
     if (settings.addressOnly || (user === undefined)) {
         user = ip;
     }
 
-    const userPath = user+':'+path;
+    const userPath = user + ':' + path;
 
     internals.userPathCache.get(userPath, (getErr, value, details) => {
 
@@ -211,13 +225,25 @@ internals.userPathCheck = function (request, settings, done) {
 
             if (remaining < 0 && settings.recaptchaSecret !== false && request.query && request.query.recaptcha) {
                 internals.verifyCaptcha(request, settings, (err, success) => {
+
                     if (err) {
-                    return done(err);
-                  }
-                  return done(null, { count, remaining, reset: ttl, success });
+                        return done(err);
+                    }
+                    return done(null, {
+                        count,
+                        remaining,
+                        reset: ttl,
+                        success
+                    });
                 });
-            } else {
-                return done(null, { count, remaining, reset: ttl, success: false });
+            }
+            else {
+                return done(null, {
+                    count,
+                    remaining,
+                    reset: ttl,
+                    success: false
+                });
             }
         });
     });
@@ -225,27 +251,30 @@ internals.userPathCheck = function (request, settings, done) {
 
 internals.verifyCaptcha = function verifyCaptcha(request, settings, done) {
 
-    let options = {
-      hostname: settings.recaptchaOptions.hostname,
-      port: settings.recaptchaOptions.port,
-      path: settings.recaptchaOptions.path + '?secret=' + settings.recaptchaSecret + '&response=' + request.query.recaptcha,
-      method: settings.recaptchaOptions.method,
-      headers: {
-        'Content-Type': 'application/json'
-      }
+    const options = {
+        hostname: settings.recaptchaOptions.hostname,
+        port: settings.recaptchaOptions.port,
+        path: settings.recaptchaOptions.path + '?secret=' + settings.recaptchaSecret + '&response=' + request.query.recaptcha,
+        method: settings.recaptchaOptions.method,
+        headers: {
+            'Content-Type': 'application/json'
+        }
     };
 
-    let get_request = https.request(options, (res) => {
-      res.setEncoding('utf8');
-      res.on('data', (body) => {
-        return done(null, JSON.parse(body).success);
-      });
-    })
+    const get_request = HTTPS.request(options, (res) => {
+
+        res.setEncoding('utf8');
+        res.on('data', (body) => {
+
+            return done(null, JSON.parse(body).success);
+        });
+    });
 
     get_request.end();
     get_request.on('error', (err) => {
-      request.log([Pkg.name, 'error'], setErr);
-      return done(Boom.badImplementation('could not call API recaptcha verify'));
+
+        request.log([Pkg.name, 'error'], setErr);
+        return done(Boom.badImplementation('could not call API recaptcha verify'));
     });
 };
 
@@ -269,7 +298,9 @@ exports.register = function (plugin, options, next) {
 
         const requestSettings = Object.assign({}, settings, routeSettings);
 
-        request.plugins[internals.pluginName] = { requestSettings };
+        request.plugins[internals.pluginName] = {
+            requestSettings
+        };
 
         if (requestSettings.enabled === false) {
             return reply.continue();
@@ -334,10 +365,18 @@ exports.register = function (plugin, options, next) {
             response.headers['X-RateLimit-UserPathRemaining'] = requestPlugin.userPathRemaining;
             response.headers['X-RateLimit-UserPathReset'] = requestPlugin.userPathReset;
         }
-        if (!response.isBoom && requestSettings.userLimit !== false && requestSettings.headers !== false) {
-            response.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
-            response.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
-            response.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
+        if (requestSettings.userLimit !== false && requestSettings.headers !== false) {
+
+            if (response.isBoom) {
+                response.output.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
+                response.output.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
+                response.output.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
+            }
+            else {
+                response.headers['X-RateLimit-UserLimit'] = requestPlugin.userLimit;
+                response.headers['X-RateLimit-UserRemaining'] = requestPlugin.userRemaining;
+                response.headers['X-RateLimit-UserReset'] = requestPlugin.userReset;
+            }
         }
         reply.continue();
     });
@@ -345,4 +384,6 @@ exports.register = function (plugin, options, next) {
     next();
 };
 
-exports.register.attributes = { pkg:  Pkg };
+exports.register.attributes = {
+    pkg: Pkg
+};


### PR DESCRIPTION
> **TODO:** tests for all this new implementation. I have no time at this moment for that. Would be fine if someone could add them.
## **Per user and path limit (#23 )**
A limit for user and path combination.

### **Options** (per-route settings)

- `userPathLimit`: `false` number of total requests that can be made on this path by a given user per period. Set to false to disable limiting requests per user on this path.
- `userPathCache`: Object with the following properties:
  - `segment`: hapi-rate-limit-path Name of the cache segment to use for storing user-path rate limit info
  - `expiresIn`: 60000 Time (in milliseconds) of period for userPathLimit

> the appropriate headers are also included.

## **Support for captcha bypass (#32 )**

> Note: Testing with Google reCaptcha. I dont know if it works with other implementation.

When user-path remaining is negative (limit reached) and 'recaptcha' field is included in query string request, the recaptcha is checked. If it is successful, rate limit is disabled (bypass) for this request.

### **Options**

- `recaptchaSecret`: `false` [secret for google recaptcha](https://developers.google.com/recaptcha/docs/verify) (The shared key between your site and reCAPTCHA.). Set to false to disable captcha verify on this path.
- `recaptchaOptions`: Object with the following properties for captcha verify request.:
  - `hostname`: `'www.google.com'`
  - `port`: `443`
  - `path`: `'/recaptcha/api/siteverify'`
  - `method`: `'GET'`
