### PR TITLE
Support custom logic to determine the Ip from the X-Forwarded-For Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ Defaults are given here
 - `headers`: `true` Whether or not to include headers in responses
 - `ipWhitelist`: `[]` array of IPs for whom to bypass rate limiting.  Note that a whitelisted IP would also bypass restrictions an authenticated user would otherwise have.
 - `trustProxy`: `false` If true, honor the `X-Forwarded-For` header.  See note below.
+- `getIpFromProxyHeader`: `undefined` a function which will extract the remote address from the `X-Forwarded-For` header. The default implementation takes the first entry.
 
 ## Users
 
 A user is considered a single `remoteAddress` for routes that are unauthenticated.  On authenticated routes it is the `userAtribute` (default `id`) of the authenticated user.
 
-If `trustProxy` is true, the address from the `X-Forwarded-For` header will be use instead of `remoteAddress`, if present
+If `trustProxy` is true, the address from the `X-Forwarded-For` header will be use instead of `remoteAddress`, if present.
+
+If `trustProxy` is true and `getIpFromProxyHeader` is not defined, the address will be determined using the first entry in the `X-Forwarded-For` header.
 
 ## Proxies
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ internals.defaults = {
     },
     pathLimit: 50,
     trustProxy: false,
+    getIpFromProxyHeader: undefined,
     userAttribute: 'id',
     userCache: {
         getDecoratedValue: true,
@@ -49,8 +50,13 @@ internals.getIP = function getIP(request, settings) {
     let ip;
 
     if (settings.trustProxy && request.headers['x-forwarded-for']) {
-        const ips = request.headers['x-forwarded-for'].split(',');
-        ip = ips[0];
+        if (settings.getIpFromProxyHeader) {
+            ip = settings.getIpFromProxyHeader(request.headers['x-forwarded-for']);
+        }
+        else {
+            const ips = request.headers['x-forwarded-for'].split(',');
+            ip = ips[0];
+        }
     }
 
     if (ip === undefined) {


### PR DESCRIPTION
This is quite useful when the proxy is not dropping incoming X-Forwarded-For values but just appending them.