### PR TITLE
Switch to using Hapi/Joi from Hoek apply defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,41 +1,41 @@
 'use strict';
 
 const Boom = require('boom');
-const Hoek = require('hoek');
+const Joi = require('joi');
 const Pkg = require('../package.json');
 
 const internals = {};
 
 internals.pluginName = Pkg.name;
 
-internals.defaults = {
-    enabled: true,
-    addressOnly: false,
-    headers: true,
-    ipWhitelist: [],
-    pathCache: {
-        getDecoratedValue: true,
-        segment: `${internals.pluginName}-path`,
-        expiresIn: 1 * 60 * 1000 //1 minute
-    },
-    pathLimit: 50,
-    trustProxy: false,
-    getIpFromProxyHeader: undefined,
-    userAttribute: 'id',
-    userCache: {
-        getDecoratedValue: true,
-        segment: `${internals.pluginName}-user`,
-        expiresIn: 10 * 60 * 1000 //10 minutes
-    },
-    userLimit: 300,
-    userWhitelist: [],
-    userPathCache: {
-        getDecoratedValue: true,
-        segment: `${internals.pluginName}-userPath`,
-        expiresIn: 1 * 60 * 1000 //1 minute
-    },
-    userPathLimit: false
-};
+internals.schema = Joi.object({
+    enabled: Joi.boolean().default(true),
+    addressOnly: Joi.boolean().default(false),
+    headers: Joi.boolean().default(true),
+    ipWhitelist: Joi.array().default([]),
+    pathCache: Joi.object({
+        getDecoratedValue: Joi.boolean().default(true),
+        segment: Joi.string().default(`${internals.pluginName}-path`),
+        expiresIn: Joi.number().default(1 * 60 * 1000) //1 minute
+    }).default(),
+    pathLimit: Joi.alternatives().try(Joi.boolean(), Joi.number()).default(50),
+    trustProxy: Joi.boolean().default(false),
+    getIpFromProxyHeader: Joi.func().default(null),
+    userAttribute: Joi.string().default('id'),
+    userCache: Joi.object({
+        getDecoratedValue: Joi.boolean().default(true),
+        segment: Joi.string().default(`${internals.pluginName}-user`),
+        expiresIn: Joi.number().default(10 * 60 * 1000) //10 minutes
+    }).default(),
+    userLimit: Joi.alternatives().try(Joi.boolean(), Joi.number()).default(300),
+    userWhitelist: Joi.array().default([]),
+    userPathCache: Joi.object({
+        getDecoratedValue: Joi.boolean().default(true),
+        segment: Joi.string().default(`${internals.pluginName}-userPath`),
+        expiresIn: Joi.number().default(1 * 60 * 1000) //1 minute
+    }).default(),
+    userPathLimit: Joi.alternatives().try(Joi.boolean(), Joi.number()).default(false)
+});
 
 internals.getUser = function getUser(request, settings) {
 
@@ -193,7 +193,7 @@ internals.userPathCheck = async function (request, settings) {
 
 const register = function (plugin, options) {
 
-    const settings = Hoek.applyToDefaults(internals.defaults, Object.assign({}, options));
+    const settings = Joi.attempt(Object.assign({}, options), internals.schema);
 
     //We call toString on the user attribute in getUser, so we have to do it here too.
     settings.userWhitelist = settings.userWhitelist.map((user) => user.toString());

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,6 +286,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -878,6 +889,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -927,6 +949,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -1058,7 +1091,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
       "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
-      "dev": true,
       "requires": {
         "punycode": "2.x.x"
       }
@@ -1070,22 +1102,13 @@
       "dev": true
     },
     "joi": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
-      "dev": true,
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.0.tgz",
+      "integrity": "sha512-0HKd1z8MWogez4GaU0LkY1FgW30vR2Kwy414GISfCU41OYgUC2GWpNe5amsvBZtDqPtt7DohykfOOMIw1Z5hvQ==",
       "requires": {
-        "hoek": "5.x.x",
+        "hoek": "6.x.x",
         "isemail": "3.x.x",
         "topo": "3.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-          "dev": true
-        }
       }
     },
     "js-yaml": {
@@ -1539,6 +1562,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -1557,8 +1591,7 @@
     "punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "regexpp": {
       "version": "2.0.0",
@@ -1667,6 +1700,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -1734,6 +1778,17 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
           "dev": true
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         }
       }
     },
@@ -1853,7 +1908,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
       "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-      "dev": true,
       "requires": {
         "hoek": "5.x.x"
       },
@@ -1861,8 +1915,7 @@
         "hoek": {
           "version": "5.0.4",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-          "dev": true
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "boom": "^7.2.0",
-    "hoek": "^6.0.0"
+    "joi": "^14.3.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
I'll preface this PR with the reason I converted the defaults and plugin configuration to use Joi was to handle a likely niche case of ours.  We use [Node Config](https://github.com/lorenwest/node-config) to merge configuration and environment variables into a single configuration file that can be used as configuration options for plugins, Hapi, or [Glue](https://github.com/hapijs/glue).  The issue we have is that environment variable values are always strings.  We noticed while providing environment variable overrides for hapi-rate-limit configuration it was barfing because `true` was `'true'` and `1` was `'1'`.

Digging into the issue I noticed that hap-rate-limit isn't using Joi  for it's plugin schema.  In addition to Joi providing sanity checks for configuration options (types, combinations, etc) it converts strings to their primitive types which solves my case.  

You might ask why not just update Node Config or write some middleware to handle my niche case.  That would have been a valid approach, but considering Joi in a way is providing a type system to the schema / configuration for the plugin it made more sense to do it once here then technically to have to do it external and keep in lock step with future changes to this plugin.  

I've updated the tests and code to test for my case and all works.