### PR TITLE
Enable ip ranges when whitelisting and ip whitelisting also for path checks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Boom = require('boom');
 const Joi = require('joi');
 const Pkg = require('../package.json');
+const RangeCheck = require('range_check');
 
 const internals = {};
 
@@ -71,9 +72,13 @@ internals.getIP = function getIP(request, settings) {
 
 internals.pathCheck = async function (request, settings) {
 
+    const ip = internals.getIP(request, settings);
     const path = request.path;
 
-    if (settings.pathLimit === false) {
+    if (
+        (RangeCheck.inRange(ip, settings.ipWhitelist)) ||
+        (settings.pathLimit === false)
+    ) {
         request.plugins[internals.pluginName].pathLimit = false;
         return { remaining: 1 };
     }
@@ -108,8 +113,9 @@ internals.userCheck = async function (request, settings) {
 
     const ip = internals.getIP(request, settings);
     let user = internals.getUser(request, settings);
+
     if (
-        (settings.ipWhitelist.indexOf(ip) > -1) ||
+        (RangeCheck.inRange(ip, settings.ipWhitelist)) ||
         (user && settings.userWhitelist.indexOf(user) > -1) ||
         (settings.userLimit === false)
     ) {
@@ -154,7 +160,7 @@ internals.userPathCheck = async function (request, settings) {
     const path = request.path;
 
     if (
-        (settings.ipWhitelist.indexOf(ip) > -1) ||
+        (RangeCheck.inRange(ip, settings.ipWhitelist)) ||
         (user && settings.userWhitelist.indexOf(user) > -1) ||
         (settings.userPathLimit === false)
     ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,6 +1111,16 @@
         "through": "^2.3.6"
       }
     },
+    "ip6": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.0.4.tgz",
+      "integrity": "sha1-RMWp23njnUBSAbTXjROzhw5I2zE="
+    },
+    "ipaddr.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+      "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1566,6 +1576,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+    },
+    "range_check": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-1.4.0.tgz",
+      "integrity": "sha1-zYfHrGLEC6nfabhwPGBPYMN0hjU=",
+      "requires": {
+        "ip6": "0.0.4",
+        "ipaddr.js": "1.2"
+      }
     },
     "regexpp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "boom": "^7.2.0",
-    "joi": "^14.3.0"
+    "joi": "^14.3.0",
+    "range_check": "^1.4.0"
   },
   "files": [
     "index.js",

--- a/test/test-routes.js
+++ b/test/test-routes.js
@@ -276,7 +276,7 @@ module.exports = [{
         },
         plugins: {
             'hapi-rate-limit': {
-                ipWhitelist: ['127.0.0.1']
+                ipWhitelist: ['127.0.0.0/16']
             }
         }
     }


### PR DESCRIPTION
This PR adds the ability to use CIDR to specify IP ranges when whitelisting IP addresses.
It also considers IP whitelisting for path checks. Was there any reason that they IP whitelists are currently not taking into account for path checks?

This PR adds a dependency on [https://github.com/keverw/range_check](https://github.com/keverw/range_check), which might or might not be acceptable.