### PR TITLE
Do not share cache instances across plugin registrations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ internals.getIP = function getIP(request, settings) {
     return ip;
 };
 
-internals.pathCheck = async function (request, settings) {
+internals.pathCheck = async function (pathCache, request, settings) {
 
     const path = request.path;
 
@@ -79,7 +79,7 @@ internals.pathCheck = async function (request, settings) {
     }
 
 
-    const { value, cached } = await internals.pathCache.get(path);
+    const { value, cached } = await pathCache.get(path);
     let count;
     let ttl = settings.pathCache.expiresIn;
 
@@ -95,7 +95,7 @@ internals.pathCheck = async function (request, settings) {
 
     const remaining = settings.pathLimit - count;
 
-    await internals.pathCache.set(path, count, ttl);
+    await pathCache.set(path, count, ttl);
 
     request.plugins[internals.pluginName].pathLimit = settings.pathLimit;
     request.plugins[internals.pluginName].pathRemaining = remaining;
@@ -104,7 +104,7 @@ internals.pathCheck = async function (request, settings) {
     return { count, remaining, reset: settings.pathCache.expiresIn };
 };
 
-internals.userCheck = async function (request, settings) {
+internals.userCheck = async function (userCache, request, settings) {
 
     const ip = internals.getIP(request, settings);
     let user = internals.getUser(request, settings);
@@ -121,7 +121,7 @@ internals.userCheck = async function (request, settings) {
         user = ip;
     }
 
-    const { value, cached } = await internals.userCache.get(user);
+    const { value, cached } = await userCache.get(user);
 
     let count;
     let ttl = settings.userCache.expiresIn;
@@ -138,7 +138,7 @@ internals.userCheck = async function (request, settings) {
 
     const remaining = settings.userLimit - count;
 
-    await internals.userCache.set(user, count, ttl);
+    await userCache.set(user, count, ttl);
 
     request.plugins[internals.pluginName].userLimit = settings.userLimit;
     request.plugins[internals.pluginName].userRemaining = remaining;
@@ -147,7 +147,7 @@ internals.userCheck = async function (request, settings) {
     return { count, remaining, reset: ttl };
 };
 
-internals.userPathCheck = async function (request, settings) {
+internals.userPathCheck = async function (userPathCache, request, settings) {
 
     const ip = internals.getIP(request, settings);
     let user = internals.getUser(request, settings);
@@ -168,7 +168,7 @@ internals.userPathCheck = async function (request, settings) {
 
     const userPath = user + ':' + path;
 
-    const { value, cached } = await internals.userPathCache.get(userPath);
+    const { value, cached } = await userPathCache.get(userPath);
 
     let count;
     let ttl = settings.userPathCache.expiresIn;
@@ -185,7 +185,7 @@ internals.userPathCheck = async function (request, settings) {
 
     const remaining = settings.userPathLimit - count;
 
-    await internals.userPathCache.set(userPath, count, ttl);
+    await userPathCache.set(userPath, count, ttl);
 
     request.plugins[internals.pluginName].userPathLimit = settings.userPathLimit;
     request.plugins[internals.pluginName].userPathRemaining = remaining;
@@ -201,9 +201,9 @@ const register = function (plugin, options) {
     //We call toString on the user attribute in getUser, so we have to do it here too.
     settings.userWhitelist = settings.userWhitelist.map((user) => user.toString());
 
-    internals.userCache = plugin.cache(settings.userCache);
-    internals.pathCache = plugin.cache(settings.pathCache);
-    internals.userPathCache = plugin.cache(settings.userPathCache);
+    const userCache = plugin.cache(settings.userCache);
+    const pathCache = plugin.cache(settings.pathCache);
+    const userPathCache = plugin.cache(settings.userPathCache);
 
     plugin.ext('onPostAuth', async (request, h) => {
 
@@ -224,9 +224,9 @@ const register = function (plugin, options) {
         }
 
         const [path, user, userPath] = await Promise.all([
-            internals.pathCheck(request, requestSettings),
-            internals.userCheck(request, requestSettings),
-            internals.userPathCheck(request, requestSettings)
+            internals.pathCheck(pathCache, request, requestSettings),
+            internals.userCheck(userCache, request, requestSettings),
+            internals.userPathCheck(userPathCache, request, requestSettings)
         ]);
 
         if (path.remaining < 0 || user.remaining < 0 || userPath.remaining < 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -338,6 +338,37 @@ describe('hapi-rate-limit', () => {
             expect(res.headers['x-ratelimit-userremaining']).to.equal(299);
         });
 
+
+        it('multiple plugin registrations do not share cache instances', async () => {
+
+            const secondServer = Hapi.server({
+                autoListen: false
+            });
+
+            secondServer.auth.scheme('trusty', () => {
+
+                return {
+                    authenticate: function (request, h) {
+
+                        return h.authenticated({ credentials: { ...request.query } });
+                    }
+                };
+            });
+            secondServer.auth.strategy('trusty', 'trusty');
+
+            await secondServer.register(HapiRateLimit);
+
+            secondServer.route(require('./test-routes'));
+            await secondServer.initialize();
+
+            let res;
+            res = await server.inject({ method: 'GET', url: '/defaults' });
+
+            res = await secondServer.inject({ method: 'GET', url: '/defaults' });
+            expect(res.headers['x-ratelimit-pathremaining']).to.equal(49);
+            expect(res.headers['x-ratelimit-userremaining']).to.equal(299);
+        });
+
     });
 
     describe('configured user limit', () => {


### PR DESCRIPTION
In the case where several Hapi servers are run from the same nodejs process and more than one of them registers the hopi-rate-limit plugin, the cache configuration are overriden and the cache used by all the registrations Is the one last registered.
This PR addresses this, so that the cache instances are not shared across registrations.