### PR TITLE
feat(response): added an option to define a custom response when the limit is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Defaults are given here
 - `ipWhitelist`: `[]` array of IPs for whom to bypass rate limiting.  Note that a whitelisted IP would also bypass restrictions an authenticated user would otherwise have.
 - `trustProxy`: `false` If true, honor the `X-Forwarded-For` header.  See note below.
 - `getIpFromProxyHeader`: `undefined` a function which will extract the remote address from the `X-Forwarded-For` header. The default implementation takes the first entry.
+- `limitExceeded`: `Boom.tooManyRequests('Rate limit exceeded');` a `function(request)` that returns a custom response to be used when the rate limit is hit. If the function returns a Boom error, it will be used. If it returns an object, the response will be 200 and the payload that object.
 
 ## Users
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Defaults are given here
 - `ipWhitelist`: `[]` array of IPs for whom to bypass rate limiting.  Note that a whitelisted IP would also bypass restrictions an authenticated user would otherwise have.
 - `trustProxy`: `false` If true, honor the `X-Forwarded-For` header.  See note below.
 - `getIpFromProxyHeader`: `undefined` a function which will extract the remote address from the `X-Forwarded-For` header. The default implementation takes the first entry.
-- `limitExceeded`: `Boom.tooManyRequests('Rate limit exceeded');` a `function(request)` that returns a custom response to be used when the rate limit is hit. If the function returns a Boom error, it will be used. If it returns an object, the response will be 200 and the payload that object.
+- `limitExceededResponse`: `() => Boom.tooManyRequests('Rate limit exceeded');` a `function(request)` that returns a custom response to be used when the rate limit is hit. If the function returns a Boom error, it will be used. If it returns an object, the response will be 200 and the payload that object.
 
 ## Users
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,8 @@ internals.schema = Joi.object({
         segment: Joi.string().default(`${internals.pluginName}-userPath`),
         expiresIn: Joi.number().default(1 * 60 * 1000) //1 minute
     }).default(),
-    userPathLimit: Joi.alternatives().try(Joi.boolean(), Joi.number()).default(false)
+    userPathLimit: Joi.alternatives().try(Joi.boolean(), Joi.number()).default(false),
+    limitExceededResponse: Joi.func()
 });
 
 internals.getUser = function getUser(request, settings) {
@@ -231,20 +232,27 @@ const register = function (plugin, options) {
 
         if (path.remaining < 0 || user.remaining < 0 || userPath.remaining < 0) {
 
-            const error = Boom.tooManyRequests('Rate limit exceeded');
-            if (requestSettings.pathLimit !== false && requestSettings.headers !== false) {
-                error.output.headers['X-RateLimit-PathLimit'] = request.plugins[internals.pluginName].pathLimit;
-                error.output.headers['X-RateLimit-PathRemaining'] = request.plugins[internals.pluginName].pathRemaining;
-                error.output.headers['X-RateLimit-PathReset'] = request.plugins[internals.pluginName].pathReset;
+            const error = options.limitExceededResponse ?
+                options.limitExceededResponse(request)
+                : Boom.tooManyRequests('Rate limit exceeded');
+
+            if (error.isBoom) {
+                if (requestSettings.pathLimit !== false && requestSettings.headers !== false) {
+                    error.output.headers['X-RateLimit-PathLimit'] = request.plugins[internals.pluginName].pathLimit;
+                    error.output.headers['X-RateLimit-PathRemaining'] = request.plugins[internals.pluginName].pathRemaining;
+                    error.output.headers['X-RateLimit-PathReset'] = request.plugins[internals.pluginName].pathReset;
+                }
+
+                if (requestSettings.userPathLimit !== false && requestSettings.headers !== false) {
+                    error.output.headers['X-RateLimit-UserPathLimit'] = request.plugins[internals.pluginName].userPathLimit;
+                    error.output.headers['X-RateLimit-UserPathRemaining'] = request.plugins[internals.pluginName].userPathRemaining;
+                    error.output.headers['X-RateLimit-UserPathReset'] = request.plugins[internals.pluginName].userPathReset;
+                }
+
+                return error; //? or h.response(err0r);
             }
 
-            if (requestSettings.userPathLimit !== false && requestSettings.headers !== false) {
-                error.output.headers['X-RateLimit-UserPathLimit'] = request.plugins[internals.pluginName].userPathLimit;
-                error.output.headers['X-RateLimit-UserPathRemaining'] = request.plugins[internals.pluginName].userPathRemaining;
-                error.output.headers['X-RateLimit-UserPathReset'] = request.plugins[internals.pluginName].userPathReset;
-            }
-
-            return error; //? or h.response(err0r);
+            return h.response(error).takeover();
         }
 
         return h.continue;


### PR DESCRIPTION
This adds the `limitExceededResponse` option to define a custom response when the limit is exceeded.

The original behavior is not touched if the option is not specified.

If the function returns a `Boom` object, it is returned. If the function returns an object, `h.response(/* whatever was returned */).takeover()` is returned.

Note that in the case where an object is returned, the following response headers are not set: `X-RateLimit-PathLimit`, `X-RateLimit-PathRemaining`, `X-RateLimit-PathReset`, `X-RateLimit-UserLimit`, `X-RateLimit-UserRemaining`, `X-RateLimit-UserReset`.