### PR TITLE
manage settings.ignorePathParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Defaults are given here
 - `userWhitelist`: `[]` array of users (as defined by `userAttribute` for whom to bypass rate limiting.  This is only applied to authenticated users, for ip whitelisting use `ipWhitelist`.
 - `addressOnly`: `false` if true, only consider user address when determining distinct authenticated users
 - `pathLimit`: `50` number of total requests that can be made on a given path per period.  Set to `false` to disable limiting requests per path.
+- `ignorePathParams`: `false` if true, the limit will be applied to the route (`/route/{param}`: single cache entry) rather than to the path (`/route/1` or `/route/2`: 2 distinct cache entries).
 - `pathCache`: Object with the following properties:
 	- `segment`: `hapi-rate-limit-path` Name of the cache segment to use for storing path rate limit info
 	- `expiresIn`: `60000` Time (in milliseconds) of period for `pathLimit`

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -31,6 +31,7 @@ const schema = Joi.object({
   pathLimit: Joi.alternatives()
     .try(Joi.boolean(), Joi.number())
     .default(50),
+	ignorePathParams: Joi.boolean().default(false),
   trustProxy: Joi.boolean().default(false),
   getIpFromProxyHeader: Joi.func().default(null),
   userAttribute: Joi.string().default('id'),
@@ -156,7 +157,7 @@ async function authCheck (authCache, request) {
 async function pathCheck (pathCache, request) {
   const requestPlugin = request.plugins[pluginName]
   const settings = requestPlugin.settings
-  const path = request.path
+  const path = settings.ignorePathParams ? request.route.path : request.path
 
   if (settings.pathLimit === false) {
     requestPlugin.pathLimit = false
@@ -241,7 +242,7 @@ async function userPathCheck (userPathCache, request) {
   const settings = requestPlugin.settings
   const ip = getIP(request, settings)
   let user = getUser(request, settings)
-  const path = request.path
+  const path = settings.ignorePathParams ? request.route.path : request.path
 
   if (
     settings.ipWhitelist.indexOf(ip) > -1 ||

--- a/test/index.js
+++ b/test/index.js
@@ -580,6 +580,66 @@ describe('hapi-rate-limit', () => {
       expect(res.headers['x-ratelimit-pathremaining']).to.equal(49)
       expect(res.headers['x-ratelimit-userremaining']).to.equal(299)
     })
+
+    it('runs out of pathLimit using params', async () => {
+      let res
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/1'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(1)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/1'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(0)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/1'
+      })
+      expect(res.statusCode).to.equal(429)
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(-1)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/2'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(1)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/2'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(0)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/managePathParams/2'
+      })
+      expect(res.statusCode).to.equal(429)
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(-1)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/ignorePathParams/1'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(1)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/ignorePathParams/2'
+      })
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(0)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/ignorePathParams/3'
+      })
+      expect(res.statusCode).to.equal(429)
+      expect(res.headers['x-ratelimit-pathremaining']).to.equal(-1)
+    })
   })
 
   describe('configured user limit', () => {

--- a/test/test-routes.js
+++ b/test/test-routes.js
@@ -313,5 +313,36 @@ module.exports = [
         }
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/managePathParams/{param}',
+    config: {
+      description: 'Route with params used by cache',
+      handler: function (request) {
+        return request.path
+      },
+      plugins: {
+        'hapi-rate-limit': {
+          pathLimit: 2
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/ignorePathParams/{param}',
+    config: {
+      description: 'Route with params ignored by cache',
+      handler: function (request) {
+        return request.path
+      },
+      plugins: {
+        'hapi-rate-limit': {
+          pathLimit: 2,
+          ignorePathParams: true
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
The purpose of this parameter is to manage the cache at the route level rather than the URL level (path).

For example, for this route `/route/{param}`, if `ignorePathParams: true`, there will be only one cached entry (e.g.: `/route/{param}`) for these two paths `/route/1` and `/route/2`