### PR TITLE
Add header resolution override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Defaults are given here
 - `ipWhitelist`: `[]` array of IPs for whom to bypass rate limiting.  Note that a whitelisted IP would also bypass restrictions an authenticated user would otherwise have.
 - `trustProxy`: `false` If true, honor the `X-Forwarded-For` header.  See note below.
 - `getIpFromProxyHeader`: `undefined` a function which will extract the remote address from the `X-Forwarded-For` header. The default implementation takes the first entry.
+- `proxyHeaderName`: `X-Forwarded-For` name of the header to use for remote address lookup.
 - `limitExceededResponse`: `() => Boom.tooManyRequests('Rate limit exceeded');` a `function(request, h)` that returns a custom response to be used when the rate limit is hit. If the function returns a Boom error, it will be used. If it returns an object, the response will be 200 and the payload whatever the function returns.
 - `authLimit`: 5 number of total separate invalid auth attempts that can be made from any given IP. Once that limit has been reached the offending IP will be blocked before hapi's auth layer runs. Set to `false` to disable this feature.
 - `authToken`: `authToken` this is the attribute that will be looked for either in auth artifacts, or in boom data for thrown errors to rate limit invalid auth attempts.  For instance you would set `artifacts.authToken` to the value of `headers.authorization` to rate limit invalid authorization headers.

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -31,7 +31,7 @@ const schema = Joi.object({
   pathLimit: Joi.alternatives()
     .try(Joi.boolean(), Joi.number())
     .default(50),
-	ignorePathParams: Joi.boolean().default(false),
+  ignorePathParams: Joi.boolean().default(false),
   trustProxy: Joi.boolean().default(false),
   getIpFromProxyHeader: Joi.func().default(null),
   proxyHeaderName: Joi.string().default('x-forwarded-for'),

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -34,6 +34,7 @@ const schema = Joi.object({
 	ignorePathParams: Joi.boolean().default(false),
   trustProxy: Joi.boolean().default(false),
   getIpFromProxyHeader: Joi.func().default(null),
+  proxyHeaderName: Joi.string().default('x-forwarded-for'),
   userAttribute: Joi.string().default('id'),
   userCache: Joi.object({
     getDecoratedValue: Joi.boolean().default(true),
@@ -71,11 +72,11 @@ function getUser (request, settings) {
 function getIP (request, settings) {
   let ip
 
-  if (settings.trustProxy && request.headers['x-forwarded-for']) {
+  if (settings.trustProxy && request.headers[settings.proxyHeaderName]) {
     if (settings.getIpFromProxyHeader) {
-      ip = settings.getIpFromProxyHeader(request.headers['x-forwarded-for'])
+      ip = settings.getIpFromProxyHeader(request.headers[settings.proxyHeaderName])
     } else {
-      const ips = request.headers['x-forwarded-for'].split(',')
+      const ips = request.headers[settings.proxyHeaderName].split(',')
       ip = ips[0]
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -499,6 +499,26 @@ describe('hapi-rate-limit', () => {
       expect(res.headers['x-ratelimit-userremaining']).to.equal(299)
     })
 
+    it('route configured trustProxy with custom header', async () => {
+      let res
+      res = await server.inject({
+        method: 'GET',
+        url: '/trustProxyCustomHeader',
+        headers: { 'x-something-else': '127.0.0.2, 127.0.0.1' }
+      })
+      expect(res.headers['x-ratelimit-userremaining']).to.equal(299)
+
+      res = await server.inject({
+        method: 'GET',
+        url: '/trustProxyCustomHeader',
+        headers: { 'x-something-else': '127.0.0.2, 127.0.0.1' }
+      })
+      expect(res.headers['x-ratelimit-userremaining']).to.equal(298)
+
+      res = await server.inject({ method: 'GET', url: '/trustProxy' })
+      expect(res.headers['x-ratelimit-userremaining']).to.equal(299)
+    })
+
     it('route configured ipWhitelist', async () => {
       const res = await server.inject({
         method: 'GET',

--- a/test/test-routes.js
+++ b/test/test-routes.js
@@ -268,6 +268,22 @@ module.exports = [
   },
   {
     method: 'GET',
+    path: '/trustProxyCustomHeader',
+    config: {
+      description: 'Route with trustProxy set and custom header name',
+      handler: function (request) {
+        return request.path
+      },
+      plugins: {
+        'hapi-rate-limit': {
+          trustProxy: true,
+          proxyHeaderName: 'x-something-else'
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: '/ipWhitelist',
     config: {
       description: 'Route with an ipWhitelist',


### PR DESCRIPTION
Hello,

kind of like #171, we need to extract the IP from another header, so I'm exposing the header name as a setting, with current header name as default value.

Let me know if you'd do it differently